### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ gulp.task('durandal', function(){
     return durandal({
             baseDir: 'app',   //same as default, so not really required.
             main: 'main.js',  //same as default, so not really required.
-            output: 'main.js', //same as default, so not really required.
+            output: 'main-built.js',
             almond: true,
             minify: true
         })


### PR DESCRIPTION
Setting the output to "main.js" will mean that the input "main.js" will then get overwritten by the built, minified output file. Changed to main-built.js as per usual Durandal convention.
