### PR TITLE
added deepExclude, generateSourceMaps options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ var PLUGIN_NAME = 'gulp-durandaljs',
         baseDir: 'app',
         main: 'main.js',
         extraModules: [],
+        deepExclude: true,
+        generateSourceMaps: true,
         durandalDynamicModules: true,
         verbose : false,
         output: undefined,
@@ -91,7 +93,7 @@ module.exports = function gulpDurandaljs(userOptions){
                     _.flatten([scannedModules.js, options.extraModules || [], dynamicModules, scannedModules.plugged])
                     .map(fixSlashes),
                 include = _.filter(modules, options.moduleFilter),
-                exclude = _.reject(modules, options.moduleFilter);
+                exclude =  options.deepExclude ? _.reject(modules, options.moduleFilter) : [];
 
             return { include:_.unique(include), exclude:_.unique(exclude) };
         })(),
@@ -141,7 +143,7 @@ module.exports = function gulpDurandaljs(userOptions){
         out: rjsCb,
         optimize: options.minify ? 'uglify2' : 'none',
         preserveLicenseComments: !options.minify,
-        generateSourceMaps : true,
+        generateSourceMaps : options.generateSourceMaps,
         insertRequire : insertRequireModules,
         wrap: almondWrapper
     };


### PR DESCRIPTION
Had to add deep exclude option (true by default). This is useful in a situation where the user may wish to ignore a folder of modules but keep any external dependencies those modules may have, such as jQuery or Knockout.

e.g. 

```
gulp.task('durandal', function(){
    return durandal({
            baseDir: 'App',
            main: 'main.js',
            //output: 'main.js', //same as default, so not really required.
            deepExclude: false,
            generateSourceMaps: false,
            almond: false,
            minify: false,
            verbose: false,
            pluginMap: {
                '.html': 'text',
                '.json': 'text',
                '.txt': 'text'
            },
            moduleFilter: function(moduleName){
                var accept = true;

                if (moduleName.indexOf('apps/') == 0) accept = false;
                if (moduleName.indexOf('text!apps/') == 0) accept =  false;
                if (moduleName.indexOf('css!apps/') == 0) accept =  false;

                var action = accept ? "Accepted" :"Skipping";
                console.log(action + ": " + moduleName);
                return accept;
            }
        })
        .pipe(gulp.dest('path/to/build'));
});
```
